### PR TITLE
version bump

### DIFF
--- a/runtime/cherry/src/lib.rs
+++ b/runtime/cherry/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("cherry"),
 	impl_name: create_runtime_str!("cherry"),
 	authoring_version: 0,
-	spec_version: 5,
+	spec_version: 7,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
bump spec version 6 -> 7
Cherry Testnet was on Version 6 based on polkadot.js UI. Might have missed opening a PR for a version bump on the previous runtime upgrade I did.