### PR TITLE
fix: naming of chain

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -46,11 +46,11 @@ fn get_exec_name() -> Option<String> {
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
-		"Cherry Mainnet".into()
+		"Cherry Relay Mainnet".into()
 	}
 
 	fn impl_version() -> String {
-		"v0.2.0-alpha".into()
+		"0.2.0-alpha".into()
 	}
 
 	fn description() -> String {

--- a/runtime/cherry/src/lib.rs
+++ b/runtime/cherry/src/lib.rs
@@ -116,10 +116,10 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 /// Runtime version (Cherry).
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("cherry"),
-	impl_name: create_runtime_str!("cherry"),
+	spec_name: create_runtime_str!("cherry-mainnet"),
+	impl_name: create_runtime_str!("cherry-mainnet"),
 	authoring_version: 0,
-	spec_version: 18,
+	spec_version: 19,
 	impl_version: 0,
 	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
change the naming of spec version